### PR TITLE
Linking kdb-haversine repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ KX Insights provides tools for deploying kdb+ systems in the cloud.
 * [kxcontrib/trend-indicators](https://github.com/kxcontrib/trend-indicators) – Trend indicators
 * [AngusWilson/whatStats](https://github.com/AngusWilson/whatStats) – Analyse WhatsApp chat logs
 * [gyorokpeter/qtcp](https://github.com/gyorokpeter/qtcp) – Open raw TCP connections in-process for q to communicate through
+* [davidcrossey/kdb-haversine](https://github.com/davidcrossey/kdb-haversine) – Haversine for q (forked from [andymans/kdb-haversine](https://github.com/andymans/kdb-haversine))
 
 
 ## Training 


### PR DESCRIPTION
I've linked a fork of the repo which contains a more accurate result when running the haversine function

For example:
![image](https://user-images.githubusercontent.com/24537293/209239707-d44b8f16-7781-4e26-8a11-4c3a6530058c.png)

The changes made are to more closely align with [Python's Haversine](https://pypi.org/project/haversine/) function.